### PR TITLE
Resolve React "unique key" issue

### DIFF
--- a/src/rojo-mail/components/views/single-view/single-view.js
+++ b/src/rojo-mail/components/views/single-view/single-view.js
@@ -47,7 +47,7 @@ export function SingleView(props) {
 			const { data } = comment;
 
 			return (
-				<div className="SingleViewCommment" key={ comment.id }>
+				<div className="SingleViewCommment" key={ data.id }>
 					<div className="SingleViewContent__Row">
 						<div className="SingleViewContent__author">
 							{ data.author }


### PR DESCRIPTION
Resolve issue where React threw a warning for violating the "unique key" rule with a list of elements.
`comment.id` was undefined; the ID was found on the `data` property of the `comment` object.