### PR TITLE
Give attachment preview a max-width

### DIFF
--- a/src/rojo-mail/components/views/inbox-view/attachment/attachment.css
+++ b/src/rojo-mail/components/views/inbox-view/attachment/attachment.css
@@ -31,6 +31,7 @@
 	padding: 25px;
 	background-color: white;
 	border: 1px solid black;
+	max-width: 200px;
 }
 
 .Attachment__pill:hover .Attachment__preview {


### PR DESCRIPTION
Give the image preview a max-width of 200px on hover, just to avoid the giant pictures taking up the whole screen :) 